### PR TITLE
QA-14549: replaced mapping

### DIFF
--- a/bootstrap5-core/src/main/resources/META-INF/spring/mod-bootstrap5-core.xml
+++ b/bootstrap5-core/src/main/resources/META-INF/spring/mod-bootstrap5-core.xml
@@ -6,9 +6,9 @@
     <bean class="org.jahia.services.render.StaticAssetMapping">
         <property name="mapping">
             <map>
-                <entry key="bootstrap.css" value="bootstrap.min.css"/>
-                <entry key="bootstrap.js" value="bootstrap.bundle.min.js"/>
-                <entry key="bootstrap.min.js" value="bootstrap.bundle.min.js"/>
+                <entry key="bootstrap5.css" value="bootstrap5.min.css"/>
+                <entry key="bootstrap5.js" value="bootstrap.bundle.min.js"/>
+                <entry key="bootstrap5.min.js" value="bootstrap.bundle.min.js"/>
                 <entry key="popper.js" value="bootstrap.bundle.min.js"/>
                 <entry key="popper.min.js" value="bootstrap.bundle.min.js"/>
             </map>


### PR DESCRIPTION
### Steps to reproduce

https://jira.jahia.org/browse/QA-14549

bootstrap3 and bootstrap5 are overriding the same static mapping, one need to be renamed. This will break modules relying on mappings to get the bootstrap5 resources ( bootstrap.css , bootstrap.js , bootstrap.min.js )