### PR TITLE
fix: prevent navbar dropdowns from overflowing viewport

### DIFF
--- a/bootstrap5-components/src/main/resources/bootstrap5nt_navbar/html/navbar.hidden.languages.jsp
+++ b/bootstrap5-components/src/main/resources/bootstrap5nt_navbar/html/navbar.hidden.languages.jsp
@@ -23,7 +23,7 @@
                    aria-expanded="false" aria-label="<fmt:message key='bootstrap5nt_navbar.label.change'/>"
                         ${fn:toUpperCase(renderContext.mainResourceLocale.language)}
                 </a>
-                <ul class="dropdown-menu" aria-labelledby="languageSwitchButton" role="menu" id="language-menu">
+                <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="languageSwitchButton" role="menu" id="language-menu">
                     <c:set var="invalidLanguages" value=""/>
                     <c:catch var="e">
                         <c:if test="${! empty mainResourceNode.properties['j:invalidLanguages']}">

--- a/bootstrap5-components/src/main/resources/bootstrap5nt_navbar/html/navbar.hidden.login.jsp
+++ b/bootstrap5-components/src/main/resources/bootstrap5nt_navbar/html/navbar.hidden.login.jsp
@@ -23,7 +23,7 @@
                  data-bs-toggle="dropdown" aria-expanded="false" role="button">
                         ${currentUser.username}
                 </a>
-                <ul class="dropdown-menu" aria-labelledby="list-${currentNode.identifier}">
+                <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="list-${currentNode.identifier}">
                     <c:if test="${!renderContext.settings.distantPublicationServerMode and renderContext.mainResource.node.properties['j:originWS'].string ne 'live' and not jcr:isNodeType(renderContext.mainResource.node.resolveSite, 'jmix:remotelyPublished')}">
                         <c:if test="${! renderContext.liveMode}">
                             <li>

--- a/bootstrap5-components/src/main/resources/css/multilevel-nav.css
+++ b/bootstrap5-components/src/main/resources/css/multilevel-nav.css
@@ -4,9 +4,7 @@
 }
 
 @media (min-width: 992px) {
-    .dropdown-menu {
-        left: auto !important;
-    }
+    /* Sub-menus (level 3+) open to the right of their parent item */
     .dropdown-menu .dropdown-menu {
         margin-left: 0;
         margin-right: 0


### PR DESCRIPTION
## Summary

- **docs**: fixed inconsistencies between markdown documentation and CND definitions (button, navbar, grid), completed the README Useful Mixins section, added Javadoc to all initializer classes and JSDoc to `multilevel-nav.js`, documented the brand resolution order (site vs local component)
- **fix**: corrected bugs found during JSP/Groovy review — missing `fn` taglib in `figure.jsp`, Bootstrap 3 markup in `carouselItem.jsp` edit mode, undefined variables (`${visibility}`, `${carouselCaptionClass}`), typo `brandImageMobileeUrl`, wrong i18n key `bootstrap5nt_navbarnavbar`, wrong package in `margin.margin.groovy`, redundant `aria-owns` on language switcher, duplicate `class` attribute on logout link, navbar dropdowns overflowing viewport when outside a container
- **feat**: replaced committed Bootstrap dist files with an npm-based build — `package.json` declares the version, `copy-bootstrap.js` copies assets at build time via `frontend-maven-plugin`; Bootstrap version is now injected dynamically into `version.jsp` from the installed package

## Test plan

- [ ] Navbar dropdown menus stay within viewport when outside a Bootstrap container

🤖 Generated with [Claude Code](https://claude.com/claude-code)
